### PR TITLE
Migrate to oss-parent as parent POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,12 @@
     <name>Aequum Library</name>
     <description>Library to aid the creation of equals, hashCode and compareTo.</description>
 
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+    </parent>
+
     <inceptionYear>2014</inceptionYear>
     <organization>
         <name>notonthehighstreet.com</name>
@@ -24,7 +30,6 @@
     <properties>
         <java.version>1.8</java.version>
         <jackson.version>2.3.3</jackson.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
@@ -213,6 +218,18 @@
                     <version>1.3.1</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.5</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5</version>
                     <configuration>
@@ -222,6 +239,25 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>no-javadoc-lint</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <scm>
         <connection>scm:git:git@github.com:notonthehighstreet/aequum.git</connection>


### PR DESCRIPTION
This will make it easier to release to Maven Central.
Also disable Javadoc lint on Java 8.
